### PR TITLE
feat: ignore client error in metric query_failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Apollo Prometheus Exporter
+
 Forked from https://github.com/bfmatei/apollo-prometheus-exporter
 
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/bfmatei/apollo-prometheus-exporter/Release)
@@ -19,6 +20,7 @@ Server v2 is still supported in v1.x.y. The two versions will be features-matche
 | `apollo_server_closing`                  | The last timestamp when Apollo Server was closing.      | Gauge     |
 | `apollo_query_started`                   | The amount of received queries.                         | Counter   |
 | `apollo_query_failed`                    | The amount of queries that failed.                      | Counter   |
+| `apollo_query_failed_by_client`          | The amount of queries that failed by client side        | Counter   |
 | `apollo_query_parse_started`             | The amount of queries for which parsing has started.    | Counter   |
 | `apollo_query_parse_failed`              | The amount of queries for which parsing has failed.     | Counter   |
 | `apollo_query_validation_started`        | The amount of queries for which validation has started. | Counter   |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hitz-group/apollo-prometheus-exporter",
-  "version": "0.0.3",
+  "version": "2.0.4",
   "description": "Plugin for Apollo Server to export metrics in Prometheus format",
   "keywords": [
     "apollo",

--- a/src/context.ts
+++ b/src/context.ts
@@ -37,6 +37,10 @@ export interface SkipMetricsMap<C extends BaseContext = AppContext, S = Source, 
   [MetricsNames.SERVER_CLOSING]: SkipFn<ServerLabels>;
   [MetricsNames.QUERY_STARTED]: SkipFnWithContext<QueryLabels, GraphQLRequestContext<C>>;
   [MetricsNames.QUERY_FAILED]: SkipFnWithContext<QueryLabels, GraphQLRequestContextDidEncounterErrors<C>>;
+  [MetricsNames.QUERY_CLIENT_FAILED_BY_CLIENT]: SkipFnWithContext<
+    QueryLabels,
+    GraphQLRequestContextDidEncounterErrors<C>
+  >;
   [MetricsNames.QUERY_PARSE_STARTED]: SkipFnWithContext<QueryLabels, GraphQLRequestContextParsingDidStart<C>>;
   [MetricsNames.QUERY_PARSE_FAILED]: SkipFnWithContext<QueryLabels, GraphQLRequestContextParsingDidStart<C>>;
   [MetricsNames.QUERY_VALIDATION_STARTED]: SkipFnWithContext<QueryLabels, GraphQLRequestContextValidationDidStart<C>>;
@@ -90,6 +94,7 @@ export function generateContext<C extends BaseContext = BaseContext, S = Source,
       [MetricsNames.SERVER_CLOSING]: () => false,
       [MetricsNames.QUERY_STARTED]: () => false,
       [MetricsNames.QUERY_FAILED]: () => false,
+      [MetricsNames.QUERY_CLIENT_FAILED_BY_CLIENT]: () => false,
       [MetricsNames.QUERY_PARSE_STARTED]: () => false,
       [MetricsNames.QUERY_PARSE_FAILED]: () => false,
       [MetricsNames.QUERY_VALIDATION_STARTED]: () => false,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -69,6 +69,7 @@ export enum MetricsNames {
   SERVER_CLOSING = 'apollo_server_closing',
   QUERY_STARTED = 'apollo_query_started',
   QUERY_FAILED = 'apollo_query_failed',
+  QUERY_CLIENT_FAILED_BY_CLIENT = 'apollo_query_failed_by_client_input',
   QUERY_PARSE_STARTED = 'apollo_query_parse_started',
   QUERY_PARSE_FAILED = 'apollo_query_parse_failed',
   QUERY_VALIDATION_STARTED = 'apollo_query_validation_started',
@@ -163,6 +164,12 @@ export const metricsConfig: MetricConfig[] = [
   {
     name: MetricsNames.QUERY_FAILED,
     help: 'The amount of queries that failed.',
+    type: MetricTypes.COUNTER,
+    labelNames: queryLabelNames
+  },
+  {
+    name: MetricsNames.QUERY_CLIENT_FAILED_BY_CLIENT,
+    help: 'The amount of queries that failed by client input.',
     type: MetricTypes.COUNTER,
     labelNames: queryLabelNames
   },


### PR DESCRIPTION
## Description
**Problem**:
- We have a high error rate, some error is type of server error (500) or client error (400).
But they are returned as Http Status 200 on Client so making affect the error rate metric on Observability dashboard in Grafana.

**Solution**
Ignore these kind of errors out of apollo_query_failed metric
`BAD_USER_INPUT`
`UNAUTHENTICATED`
`GRAPHQL_PARSE_FAILED `
`GRAPHQL_VALIDATION_FAILED `
`BAD_REQUEST`


## Related Issues

Ticket: [#OD-411](https://oolio.atlassian.net/browse/OD-411)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if appropriate):
