### PR TITLE
chore: make error INVALID_CREDENTIALS as QUERY_FAILED_BY_CLIENT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hitz-group/apollo-prometheus-exporter",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Plugin for Apollo Server to export metrics in Prometheus format",
   "keywords": [
     "apollo",

--- a/src/context.ts
+++ b/src/context.ts
@@ -37,10 +37,7 @@ export interface SkipMetricsMap<C extends BaseContext = AppContext, S = Source, 
   [MetricsNames.SERVER_CLOSING]: SkipFn<ServerLabels>;
   [MetricsNames.QUERY_STARTED]: SkipFnWithContext<QueryLabels, GraphQLRequestContext<C>>;
   [MetricsNames.QUERY_FAILED]: SkipFnWithContext<QueryLabels, GraphQLRequestContextDidEncounterErrors<C>>;
-  [MetricsNames.QUERY_CLIENT_FAILED_BY_CLIENT]: SkipFnWithContext<
-    QueryLabels,
-    GraphQLRequestContextDidEncounterErrors<C>
-  >;
+  [MetricsNames.QUERY_FAILED_BY_CLIENT]: SkipFnWithContext<QueryLabels, GraphQLRequestContextDidEncounterErrors<C>>;
   [MetricsNames.QUERY_PARSE_STARTED]: SkipFnWithContext<QueryLabels, GraphQLRequestContextParsingDidStart<C>>;
   [MetricsNames.QUERY_PARSE_FAILED]: SkipFnWithContext<QueryLabels, GraphQLRequestContextParsingDidStart<C>>;
   [MetricsNames.QUERY_VALIDATION_STARTED]: SkipFnWithContext<QueryLabels, GraphQLRequestContextValidationDidStart<C>>;
@@ -94,7 +91,7 @@ export function generateContext<C extends BaseContext = BaseContext, S = Source,
       [MetricsNames.SERVER_CLOSING]: () => false,
       [MetricsNames.QUERY_STARTED]: () => false,
       [MetricsNames.QUERY_FAILED]: () => false,
-      [MetricsNames.QUERY_CLIENT_FAILED_BY_CLIENT]: () => false,
+      [MetricsNames.QUERY_FAILED_BY_CLIENT]: () => false,
       [MetricsNames.QUERY_PARSE_STARTED]: () => false,
       [MetricsNames.QUERY_PARSE_FAILED]: () => false,
       [MetricsNames.QUERY_VALIDATION_STARTED]: () => false,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -6,7 +6,7 @@ import { Counter, Gauge, Histogram, LabelValues } from 'prom-client';
 import { convertMsToS, filterLabels } from './helpers';
 import { ContextTypes, FieldTypes, MetricsNames, Metrics, MetricTypes } from './metrics';
 
-const BAD_USER_INPUT = 'BAD_USER_INPUT';
+const clientErrors = ['BAD_USER_INPUT', 'INVALID_CREDENTIALS'];
 
 export function getLabelsFromContext(context: any): LabelValues<string> {
   return {
@@ -212,13 +212,13 @@ export function generateHooks(metrics: Metrics): ApolloServerPlugin {
         async didEncounterErrors(context) {
           const requestEndDate = Date.now();
           const hasBadUserInput = (context.errors || []).some((error) => {
-            return BAD_USER_INPUT === error?.extensions?.code;
+            return clientErrors.some((err) => err === error?.extensions?.code);
           });
 
           if (hasBadUserInput) {
             actionMetric(
               {
-                name: MetricsNames.QUERY_CLIENT_FAILED_BY_CLIENT,
+                name: MetricsNames.QUERY_FAILED_BY_CLIENT,
                 labels: getLabelsFromContext(context)
               },
               context

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -69,7 +69,7 @@ export enum MetricsNames {
   SERVER_CLOSING = 'apollo_server_closing',
   QUERY_STARTED = 'apollo_query_started',
   QUERY_FAILED = 'apollo_query_failed',
-  QUERY_CLIENT_FAILED_BY_CLIENT = 'apollo_query_failed_by_client_input',
+  QUERY_FAILED_BY_CLIENT = 'apollo_query_failed_by_client_input',
   QUERY_PARSE_STARTED = 'apollo_query_parse_started',
   QUERY_PARSE_FAILED = 'apollo_query_parse_failed',
   QUERY_VALIDATION_STARTED = 'apollo_query_validation_started',
@@ -168,7 +168,7 @@ export const metricsConfig: MetricConfig[] = [
     labelNames: queryLabelNames
   },
   {
-    name: MetricsNames.QUERY_CLIENT_FAILED_BY_CLIENT,
+    name: MetricsNames.QUERY_FAILED_BY_CLIENT,
     help: 'The amount of queries that failed by client input.',
     type: MetricTypes.COUNTER,
     labelNames: queryLabelNames


### PR DESCRIPTION
## Description
- When customer login with incorrect username and password it will throw error with code INVALID_CREDENTIALS which should be count as a client cause of error 

## Ticket
Ticket [#OD-461](https://oolio.atlassian.net/browse/OD-461)

